### PR TITLE
Handle multiple CertificateClaim_Flag in a single cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ Repl Identity stores a `REPL_IDENTITY` token in every Repl automatically. This
 token is a signed [PASETO](https://paseto.io) that includes verifiable repl
 identity data (such as the user in the repl, and the repl ID).
 
-**WARNING: in their current form, these tokens are very forwardable! You should
-only send these tokens to repls that you trust, or between repls that you own.**
-
 This package provides the necessary code to verify these tokens.
 
 Check the example at `examples/extract.go` for an example usage. You can also

--- a/verify.go
+++ b/verify.go
@@ -108,9 +108,15 @@ func (v *verifier) verifyCert(certBytes []byte, signingCert *api.GovalCert) (*ap
 		for _, claim := range cert.Claims {
 			switch tc := claim.Claim.(type) {
 			case *api.CertificateClaim_Flag:
-				v.anyReplid = tc.Flag == api.FlagClaim_ANY_REPLID
-				v.anyUser = tc.Flag == api.FlagClaim_ANY_USER
-				v.anyCluster = tc.Flag == api.FlagClaim_ANY_CLUSTER
+				if tc.Flag == api.FlagClaim_ANY_REPLID {
+					v.anyReplid = true
+				}
+				if tc.Flag == api.FlagClaim_ANY_USER {
+					v.anyUser = true
+				}
+				if tc.Flag == api.FlagClaim_ANY_CLUSTER {
+					v.anyCluster = true
+				}
 			case *api.CertificateClaim_Replid:
 				if anyReplid {
 					continue


### PR DESCRIPTION
If there are multiple `CertificateClaim_Flag` in a certificate, and more than one is an `ANY_*`, the previous code would choose the last one in the certificate and ignore the "any" state of the previous ones.

Now, we'll compose the `v.any*` variables from the multiple claims instead.