### PR TITLE
Include UserId in leaf tokens

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -86,6 +86,7 @@ func (a *SigningAuthority) Sign(audience string) (string, error) {
 		Slug:         a.identity.Slug,
 		Aud:          audience,
 		OriginReplid: a.identity.OriginReplid,
+		UserId:       a.identity.UserId,
 	}
 
 	token, err := signIdentity(a.privateKey, a.signingAuthority, &replIdentity)

--- a/sign_test.go
+++ b/sign_test.go
@@ -477,6 +477,7 @@ func TestAnyReplIDIdentity(t *testing.T) {
 		User:   "user",
 		Slug:   "slug",
 		Aud:    "another-audience",
+		UserId: 1,
 	}
 
 	privkey, identity, err := identityTokenAnyRepl("repl", "user", "slug")
@@ -516,4 +517,5 @@ func TestAnyReplIDIdentity(t *testing.T) {
 	assert.Equal(t, "a-b-c-d", replIdentity.Replid)
 	assert.Equal(t, "user", replIdentity.User)
 	assert.Equal(t, "slug", replIdentity.Slug)
+	assert.Equal(t, int64(1), replIdentity.UserId)
 }


### PR DESCRIPTION
Tokens minted by the replit CLI were missing the `UserId`. This includes
the UserId in the signed token.

Added a check for this in the existing test.
