### PR TITLE
Check IDENTITY claim when verifying identity

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -281,9 +281,11 @@ func VerifyIdentity(message string, audience string, getPubKey PubKeySource, opt
 	}
 
 	if v.claims != nil {
-		if _, ok := v.claims.Flags[api.FlagClaim_MINT_GOVAL_TOKEN]; !ok {
+		if _, ok := v.claims.Flags[api.FlagClaim_IDENTITY]; !ok {
 			return nil, errors.New("token not authorized for identity")
 		}
+	} else {
+		return nil, errors.New("token not authorized for identity")
 	}
 
 	for _, option := range options {

--- a/verify.go
+++ b/verify.go
@@ -280,6 +280,12 @@ func VerifyIdentity(message string, audience string, getPubKey PubKeySource, opt
 		return nil, fmt.Errorf("claim mismatch: %w", err)
 	}
 
+	if v.claims != nil {
+		if _, ok := v.claims.Flags[api.FlagClaim_MINT_GOVAL_TOKEN]; !ok {
+			return nil, errors.New("token not authorized for identity")
+		}
+	}
+
 	for _, option := range options {
 		err = option.verify(&identity)
 		if err != nil {


### PR DESCRIPTION
We store a set of flags in the Identity token. One of those is `IDENTITY`. We should check if that flag exists in the intermediate cert when verifying an identiity.

This should not impact any users since all REPL_IDENTITY tokens issued contain the necessary bits. It also adds the capability of checking other non-identity claims for identity purposes (e.g. renewal).