### PR TITLE
Add convenience function for verifying token flags

### DIFF
--- a/api/signing.pb.go
+++ b/api/signing.pb.go
@@ -81,10 +81,6 @@ const (
 	FlagClaim_SIGN_INTERMEDIATE_CERT FlagClaim = 1
 	// Cert has the authority to sign GovalToken messages that can prove identity.
 	FlagClaim_IDENTITY FlagClaim = 5
-		// Cert has ability to mint Repl Identity tokens
-		FlagClaim_RENEW_IDENTITY FlagClaim = 7
-		// Cert has abilit to mint Repl KV tokens
-		FlagClaim_RENEW_KV FlagClaim = 8
 	// Cert has the authority to sign GovalToken messages that authorizes the
 	// bearer to use Ghostwriter.
 	FlagClaim_GHOSTWRITER FlagClaim = 6

--- a/api/signing.pb.go
+++ b/api/signing.pb.go
@@ -81,6 +81,10 @@ const (
 	FlagClaim_SIGN_INTERMEDIATE_CERT FlagClaim = 1
 	// Cert has the authority to sign GovalToken messages that can prove identity.
 	FlagClaim_IDENTITY FlagClaim = 5
+		// Cert has ability to mint Repl Identity tokens
+		FlagClaim_RENEW_IDENTITY FlagClaim = 7
+		// Cert has abilit to mint Repl KV tokens
+		FlagClaim_RENEW_KV FlagClaim = 8
 	// Cert has the authority to sign GovalToken messages that authorizes the
 	// bearer to use Ghostwriter.
 	FlagClaim_GHOSTWRITER FlagClaim = 6

--- a/sign_test.go
+++ b/sign_test.go
@@ -406,9 +406,9 @@ func TestNoIdentityClaim(t *testing.T) {
 		"testing",
 		getPubKey,
 	)
-	// Check that we got a 'token not authorized for identity' error
+	// Check that we got a 'token not authorized for flag IDENTITY' error
 	require.Error(t, err)
-	assert.Equal(t, "token not authorized for identity", err.Error())
+	assert.Equal(t, "token not authorized for flag IDENTITY", err.Error())
 }
 
 func TestOriginIdentity(t *testing.T) {

--- a/verify.go
+++ b/verify.go
@@ -259,23 +259,6 @@ func VerifyIdentity(message string, audience string, getPubKey PubKeySource, opt
 	return VerifyToken(opts)
 }
 
-// VerifyRenewIdentity verifies that the given `REPL_RENEWAL` value is in fact
-// signed by Goval's chain of authority, addressed to the provided audience
-// (the `REPL_ID` of the recipient), and has the capability to renew the
-// identity.
-//
-// The optional options allow specifying additional verifications on the identity.
-func VerifyRenewIdentity(message string, audience string, getPubKey PubKeySource, options ...VerifyOption) (*api.GovalReplIdentity, error) {
-	opts := VerifyTokenOpts{
-		Message:   message,
-		Audience:  audience,
-		GetPubKey: getPubKey,
-		Options:   options,
-		Flags:     []api.FlagClaim{api.FlagClaim_RENEW_IDENTITY},
-	}
-	return VerifyToken(opts)
-}
-
 type VerifyTokenOpts struct {
 	Message   string
 	Audience  string


### PR DESCRIPTION
We store a set of flags in the Identity token. For convenience, let's add a function that checks that an identity is valid while checking that it contains a given list of flags. This will allow us to easily use identity tokens for other purposes.