### PR TITLE
Read identity token and key from file

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -22,8 +22,8 @@ type SigningAuthority struct {
 }
 
 // NewSigningAuthority returns a new SigningAuthority given the marshaled
-// private key (obtained from the `REPL_IDENTITY_KEY` environment variable),
-// the identity token (obtained from the `REPL_IDENTITY` environment variable),
+// private key (obtained from the `REPL_IDENTITY_KEY` environment variable or /etc/replidentity.key),
+// the identity token (obtained from the `REPL_IDENTITY` environment variable or /etc/replidentity),
 // the current Repl ID (obtained from the `REPL_ID` environment varaible), and
 // the source of public keys (typically [ReadPublicKeyFromEnv]).
 func NewSigningAuthority(


### PR DESCRIPTION
The identity tokens placed in a Repl when it boots up last for 36h. This is fine for shorter lasting Repls, but if we want to have long-running Repls we need a mechanism to refresh the identity.

Let's make it so that we transparently read the identity data from a file, which contrary to an environment variable can be refreshed while a program is running.
