### PR TITLE
Revert "[incident] Temporarily disable deployments-checking"

### DIFF
--- a/sign_test.go
+++ b/sign_test.go
@@ -643,17 +643,16 @@ func TestSpoofedRuntimeIdentity(t *testing.T) {
 				},
 			},
 		},
-		// TODO: Reenable this once we understand what's going wrong.
-		// {
-		// 	Replid: "a-b-c-d",
-		// 	User:   "user",
-		// 	UserId: 1,
-		// 	Slug:   "slug",
-		// 	Aud:    "another-audience",
-		// 	Runtime: &api.GovalReplIdentity_Deployment{
-		// 		Deployment: &api.ReplRuntimeDeployment{},
-		// 	},
-		// },
+		{
+			Replid: "a-b-c-d",
+			User:   "user",
+			UserId: 1,
+			Slug:   "slug",
+			Aud:    "another-audience",
+			Runtime: &api.GovalReplIdentity_Deployment{
+				Deployment: &api.ReplRuntimeDeployment{},
+			},
+		},
 	} {
 		layeredReplIdentity := layeredReplIdentity
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {

--- a/verify.go
+++ b/verify.go
@@ -431,10 +431,9 @@ func verifyRawClaims(
 			}
 		}
 
-		// TODO: Reenable this once we understand what's going wrong.
-		// if deployment && !allowsDeployment {
-		//	return errors.New("not authorized (deployment)")
-		// }
+		if deployment && !allowsDeployment {
+			return errors.New("not authorized (deployment)")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Reverts replit/go-replidentity#25

That was just a temporary change and we figured out the bug.