### PR TITLE
[debug] Add a function to dump the token contents

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -76,6 +76,10 @@ func NewSigningAuthority(
 	}, nil
 }
 
+func (s *SigningAuthority) String() string {
+	return fmt.Sprintf("SigningAuthority{signingAuthority: %s, identity: %s}", s.signingAuthority, s.identity)
+}
+
 // Sign generates a new token that can be given to the provided audience, and
 // is resistant against forwarding, so that the recipient cannot forward this
 // token to another repl and claim it came directly from you.


### PR DESCRIPTION
It used to be very hard to know what tokens contain.

This change adds `DumpTokenAsString()`, which does _not_ perform any validation and still dumps the contents of the token for debugging purposes. This prints the contents of the identity as well as the full authority chain.


Sample output:

```shell
raw token:
  v2.public.Q2lSbVpUQTNaRGhqTUMweU5XWTBMVFF6WVRndE9USmpZaTB3
    ... snip ...
    XWkhSU2JFNVRaVzFuTUE9PQ
decoded token:
  {
    "replid":  "fe07d8c0-25f4-43a8-92cb-015abea73557",
    "user":  "luisbirb",
    "slug":  "ReplitIdentity",
    "aud":  "fe07d8c0-25f4-43a8-92cb-015abea73557",
    "userId":  "8340069",
    "interactive":  {
      "cluster":  "canary",
      "subcluster":  "interactive"
    }
  }
signing authority chain:
  signing authority:
    {
      "signedCert":  "v2.public.Q2d3SXVZUGRwd1lRdFBUbzVRRVNE
        ... snip ...
        1ZOdVdtRlNSemg0",
      "version":  "TYPE_AWARE_TOKEN",
      "issuer":  "conman"
    }
  certificate:
    {
      "iat":  "2023-09-05T14:56:57.481966644Z",
      "exp":  "2023-09-07T02:57:12.481967Z",
      "claims":  [
        {
          "flag":  "IDENTITY"
        },
        {
          "replid":  "fe07d8c0-25f4-43a8-92cb-015abea73557"
        },
        {
          "user":  "luisbirb"
        },
        {
          "userId":  "8340069"
        },
        {
          "cluster":  "canary"
        },
        {
          "subcluster":  "interactive"
        }
      ],
      "publicKey":  "k2.public.kyStzkqHe7Xlz-ZPXhUkx34ae-IKL
        3rGVEUi6DfnodU"
    }

  signing authority:
    {
      "signedCert":  "v2.public.Q2d3SW40N0Vwd1lRcGZhbGxRSVNE
        ... snip ...
        zwujI1qTNA7iYKEO.R0FFaUJtTnZibTFoYmdvR2NISnZaRG8x",
      "version":  "TYPE_AWARE_TOKEN",
      "issuer":  "conman"
    }
  certificate:
    {
      "iat":  "2023-08-31T21:33:19.581532453Z",
      "exp":  "2123-08-07T21:33:34.581533990Z",
      "claims":  [
        {
          "flag":  "SIGN_INTERMEDIATE_CERT"
        },
        {
          "flag":  "IDENTITY"
        },
        {
          "flag":  "RENEW_IDENTITY"
        },
        {
          "flag":  "RENEW_KV"
        },
        {
          "flag":  "DEPLOYMENTS"
        },
        {
          "flag":  "ANY_REPLID"
        },
        {
          "flag":  "ANY_USER"
        },
        {
          "flag":  "ANY_USER_ID"
        },
        {
          "flag":  "ANY_CLUSTER"
        },
        {
          "flag":  "ANY_SUBCLUSTER"
        }
      ],
      "publicKey":  "k2.public._pZvgkAGAd8Nx3kwZmdGj1UG6nb6V
        R4wO_NaMXAj1_Y"
    }

  signing authority:
    {
      "keyId":  "prod:5",
      "version":  "TYPE_AWARE_TOKEN",
      "issuer":  "conman"
    }
```