### PR TITLE
Allow more than once audience

### DIFF
--- a/examples/extract.go
+++ b/examples/extract.go
@@ -25,7 +25,7 @@ func main() {
 	// audience := os.Getenv("REPL_ID") // uncomment this on the other Repl.
 	replIdentity, err := replidentity.VerifyIdentity(
 		identityToken,
-		audience,
+		[]string{audience},
 		replidentity.ReadPublicKeyFromEnv,
 	)
 	if err != nil {

--- a/identity_test.go
+++ b/identity_test.go
@@ -43,7 +43,7 @@ func Example() {
 	// Verify the signed token, pretending we are the target repl.
 	replIdentity, err := replidentity.VerifyIdentity(
 		signedToken,
-		targetRepl,
+		[]string{targetRepl},
 		replidentity.ReadPublicKeyFromEnv,
 	)
 	if err != nil {
@@ -97,7 +97,7 @@ func ExampleRenew() {
 	// Verify the signed token, pretending we are the target repl.
 	replIdentity, err := replidentity.VerifyRenewIdentity(
 		signedToken,
-		targetRepl,
+		[]string{targetRepl},
 		replidentity.ReadPublicKeyFromEnv,
 	)
 	if err != nil {

--- a/sign_test.go
+++ b/sign_test.go
@@ -382,7 +382,7 @@ func TestIdentity(t *testing.T) {
 
 	replIdentity, err := VerifyIdentity(
 		forwarded,
-		"testing",
+		[]string{"testing"},
 		getPubKey,
 	)
 	require.NoError(t, err)
@@ -391,7 +391,7 @@ func TestIdentity(t *testing.T) {
 	// (they're not guest forks, replID can be used)
 	_, err = VerifyIdentity(
 		forwarded,
-		"testing",
+		[]string{"testing"},
 		getPubKey,
 		WithSource("origin"),
 	)
@@ -443,7 +443,7 @@ func TestNoIdentityClaim(t *testing.T) {
 
 	_, err = VerifyIdentity(
 		forwarded,
-		"testing",
+		[]string{"testing"},
 		getPubKey,
 	)
 	// Check that we got a 'token not authorized for flag IDENTITY' error
@@ -479,7 +479,7 @@ func TestOriginIdentity(t *testing.T) {
 
 	replIdentity, err := VerifyIdentity(
 		forwarded,
-		"testing",
+		[]string{"testing"},
 		getPubKey,
 		WithSource("origin"),
 	)
@@ -487,7 +487,7 @@ func TestOriginIdentity(t *testing.T) {
 
 	_, err = VerifyIdentity(
 		forwarded,
-		"testing",
+		[]string{"testing"},
 		getPubKey,
 		WithSource("another-origin"),
 	)
@@ -541,7 +541,7 @@ func TestLayeredIdentity(t *testing.T) {
 		// the audience claim mismatch fails too early. we need to make sure we don't trust
 		// the wrong level of replid/user/slug, because another repl could use its private
 		// key to sign a spoofed identity with a "valid" audience.
-		"another-audience",
+		[]string{"another-audience"},
 		getPubKey,
 	)
 	require.Error(t, err)
@@ -617,7 +617,7 @@ func TestAnyReplIDIdentity(t *testing.T) {
 
 	replIdentity, err := VerifyIdentity(
 		token,
-		"another-audience",
+		[]string{"another-audience"},
 		getPubKey,
 	)
 	require.NoError(t, err)
@@ -698,7 +698,7 @@ func TestSpoofedRuntimeIdentity(t *testing.T) {
 
 			_, err = VerifyIdentity(
 				token,
-				"another-audience",
+				[]string{"another-audience"},
 				getPubKey,
 			)
 			assert.Error(t, err)
@@ -734,7 +734,7 @@ func TestRenew(t *testing.T) {
 
 	replIdentity, err := VerifyRenewIdentity(
 		forwarded,
-		"testing",
+		[]string{"testing"},
 		getPubKey,
 	)
 	require.NoError(t, err)
@@ -782,7 +782,7 @@ func TestRenewNoClaim(t *testing.T) {
 
 	_, err = VerifyRenewIdentity(
 		forwarded,
-		"testing",
+		[]string{"testing"},
 		getPubKey,
 	)
 	require.Error(t, err)

--- a/verify.go
+++ b/verify.go
@@ -311,7 +311,7 @@ func WithSource(sourceReplid string) VerifyOption {
 // (the `REPL_ID` of the recipient).
 //
 // The optional options allow specifying additional verifications on the identity.
-func VerifyIdentity(message string, audience string, getPubKey PubKeySource, options ...VerifyOption) (*api.GovalReplIdentity, error) {
+func VerifyIdentity(message string, audience []string, getPubKey PubKeySource, options ...VerifyOption) (*api.GovalReplIdentity, error) {
 	opts := VerifyTokenOpts{
 		Message:   message,
 		Audience:  audience,
@@ -328,7 +328,7 @@ func VerifyIdentity(message string, audience string, getPubKey PubKeySource, opt
 // identity.
 //
 // The optional options allow specifying additional verifications on the identity.
-func VerifyRenewIdentity(message string, audience string, getPubKey PubKeySource, options ...VerifyOption) (*api.GovalReplIdentity, error) {
+func VerifyRenewIdentity(message string, audience []string, getPubKey PubKeySource, options ...VerifyOption) (*api.GovalReplIdentity, error) {
 	opts := VerifyTokenOpts{
 		Message:   message,
 		Audience:  audience,
@@ -341,7 +341,7 @@ func VerifyRenewIdentity(message string, audience string, getPubKey PubKeySource
 
 type VerifyTokenOpts struct {
 	Message   string
-	Audience  string
+	Audience  []string
 	GetPubKey PubKeySource
 	Options   []VerifyOption
 	Flags     []api.FlagClaim
@@ -375,7 +375,14 @@ func VerifyToken(opts VerifyTokenOpts) (*api.GovalReplIdentity, error) {
 		}
 	}
 
-	if opts.Audience != identity.Aud {
+	var validAudience bool
+	for _, aud := range opts.Audience {
+		if aud == identity.Aud {
+			validAudience = true
+			break
+		}
+	}
+	if !validAudience {
 		return nil, fmt.Errorf("message identity mismatch. expected %q, got %q", opts.Audience, identity.Aud)
 	}
 


### PR DESCRIPTION
It is sometimes desirable to allow multiple audiences while validating a token.

This change allows the caller to supply more than one audience for validation.

this library is still v0, which means that we are not beholden by the Golang compatibility guarantee (yet).