### PR TITLE
[box] Add library code to encrypt / decrypt messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Repl Identity
 
-Blog post on https://blog.replit.com coming soon!
+[![Go Reference](https://pkg.go.dev/badge/github.com/replit/go-replidentity.svg)](https://pkg.go.dev/github.com/replit/go-replidentity)
+
+Blog post: https://blog.replit.com/repl-identity
 
 Repl Identity stores a `REPL_IDENTITY` token in every Repl automatically. This
 token is a signed [PASETO](https://paseto.io) that includes verifiable repl

--- a/box.go
+++ b/box.go
@@ -1,0 +1,63 @@
+package replidentity
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/nacl/box"
+
+	"github.com/replit/go-replidentity/paserk"
+)
+
+// SealAnonymousBox encrypts a message using the public key of the certificate.
+// Only the private key can decrypt the message.
+//
+// This uses
+// https://pkg.go.dev/golang.org/x/crypto@v0.42.0/nacl/box#SealAnonymous, and
+// uses the ed25519 public key embedded in the certificate (converted to
+// curve25519 public key).
+func (v *VerifiedToken) SealAnonymousBox(message []byte, rand io.Reader) ([]byte, error) {
+	pubkey, err := paserk.PASERKPublicToPublicKey(paserk.PASERKPublic(v.Certificate.GetPublicKey()))
+	if err != nil {
+		return nil, fmt.Errorf("paserk public key to ed25519 public key: %w", err)
+	}
+
+	curve25519Pubkey, err := Ed25519PublicKeyToCurve25519(pubkey)
+	if err != nil {
+		return nil, fmt.Errorf("ed25519 public key to curve25519 public key: %w", err)
+	}
+
+	result, err := box.SealAnonymous(
+		nil,
+		message,
+		&curve25519Pubkey,
+		rand,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("box.SealAnonymous: %w", err)
+	}
+
+	return result, nil
+}
+
+// OpenAnonymousBox decrypts a message encrypted with [SealAnonymousBox] using
+// the private key of the signature authority.
+//
+// This uses
+// https://pkg.go.dev/golang.org/x/crypto@v0.42.0/nacl/box#OpenAnonymous, and
+// uses the ed25519 private key (converted to curve25519 private key).
+func (s *SigningAuthority) OpenAnonymousBox(sealedBox []byte) ([]byte, error) {
+	curve25519Privkey := Ed25519PrivateKeyToCurve25519(s.privateKey)
+	curve25519Pubkey, err := Ed25519PublicKeyToCurve25519(s.privateKey.Public().(ed25519.PublicKey))
+	if err != nil {
+		return nil, fmt.Errorf("ed25519 private key to curve25519 private key: %w", err)
+	}
+
+	message, ok := box.OpenAnonymous(nil, sealedBox, &curve25519Pubkey, &curve25519Privkey)
+	if !ok {
+		return nil, fmt.Errorf("box.OpenAnonymous")
+	}
+
+	return message, nil
+}

--- a/box_test.go
+++ b/box_test.go
@@ -1,0 +1,60 @@
+package replidentity
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/replit/go-replidentity/paserk"
+	"github.com/replit/go-replidentity/protos/external/goval/api"
+)
+
+func TestBoxAnonymous(t *testing.T) {
+	privkey, identity, err := identityToken("repl", "user", 1, "slug")
+	require.NoError(t, err)
+
+	getPubKey := func(keyid, issuer string) (ed25519.PublicKey, error) {
+		if keyid != developmentKeyID {
+			return nil, nil
+		}
+		keyBytes, err := base64.StdEncoding.DecodeString(developmentPublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse public key as base64: %w", err)
+		}
+
+		return ed25519.PublicKey(keyBytes), nil
+	}
+
+	signingAuthority, err := NewSigningAuthority(
+		string(paserk.PrivateKeyToPASERKSecret(privkey)),
+		identity,
+		"repl",
+		getPubKey,
+	)
+	require.NoError(t, err)
+	forwarded, err := signingAuthority.Sign("testing")
+	require.NoError(t, err)
+
+	verifiedToken, err := VerifyToken(VerifyTokenOpts{
+		Message: forwarded,
+		Audience: []string{"testing"},
+		GetPubKey: getPubKey,
+		Flags:     []api.FlagClaim{api.FlagClaim_IDENTITY},
+	})
+	require.NoError(t, err)
+
+	secret := "secret message"
+
+	sealedBox, err := verifiedToken.SealAnonymousBox([]byte(secret), rand.Reader)
+	require.NoError(t, err)
+
+	unsealedBox, err := signingAuthority.OpenAnonymousBox(sealedBox)
+	require.NoError(t, err)
+
+	assert.Equal(t, secret, string(unsealedBox))
+}

--- a/verify.go
+++ b/verify.go
@@ -381,9 +381,9 @@ type VerifiedToken struct {
 	Certificate      *api.GovalCert
 }
 
-// VerifyToken verifies that the given `REPL_IDENTITY` value is in fact
-// signed by Goval's chain of authority, and addressed to the provided audience
-// (the `REPL_ID` of the recipient).
+// VerifyToken verifies that the given `REPL_IDENTITY` value is in fact signed
+// by Goval's chain of authority, and addressed to the provided audience (the
+// `REPL_ID` of the recipient). This is the preferred way of verifying tokens.
 //
 // The optional options allow specifying additional verifications on the identity.
 func VerifyToken(opts VerifyTokenOpts) (*VerifiedToken, error) {


### PR DESCRIPTION
Turns out that we already have an asymmetric cryptography keypair in every Repl! But they're a ed25519 keypair, which is only used for signing messages. Well, it turns out that it is possible to convert an ed25519 keypair to a curve25519 keypair. And NaCl's public-key authenticated encryption primitive
([box](https://nacl.cr.yp.to/box.html)) uses curve25519.

This change adds two library functions to encrypt a message address to a Repl given a Repl Identity token, and then have that Repl be able to decrypt it.